### PR TITLE
update viper ReadInConfig error handler

### DIFF
--- a/cmd/go-graphkb/main.go
+++ b/cmd/go-graphkb/main.go
@@ -95,7 +95,11 @@ func onInit() {
 	viper.SetConfigType("yaml")
 
 	if err := viper.ReadInConfig(); err != nil {
-		panic(fmt.Errorf("Cannot read configuration file from %s", ConfigPath))
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			fmt.Printf("no configuration file %q, skipping and using env variable", ConfigPath)
+		} else {
+			panic(fmt.Errorf("cannot read configuration file from %s", ConfigPath))
+		}
 	}
 
 	logrus.Info("Using config file: ", viper.ConfigFileUsed())


### PR DESCRIPTION
* viper use both config file & env variable to retrieve config settings
* if config file isn't found, just continue the execution, and find the
config settings using env var