### PR TITLE
fix: response was json encoded twice in query handler

### DIFF
--- a/internal/handlers/handler_query.go
+++ b/internal/handlers/handler_query.go
@@ -67,7 +67,7 @@ func PostQuery(database knowledge.GraphDB, queryHistorizer history.Historizer, c
 			response = res
 		}
 
-		err = json.NewEncoder(w).Encode(response)
+		_, err = w.Write(response)
 		if err != nil {
 			ReplyWithInternalError(w, err)
 		}


### PR DESCRIPTION
The introduction of the cache contained a bug wich caused the result to
be json encoded twice. This fixes it.