### PR TITLE
query cache: set default cache ttl to 10 minutes

### DIFF
--- a/internal/handlers/handler_query.go
+++ b/internal/handlers/handler_query.go
@@ -63,7 +63,7 @@ func PostQuery(database knowledge.GraphDB, queryHistorizer history.Historizer, c
 				ReplyWithInternalError(w, err)
 				return
 			}
-			cache.SetDefault(cacheKey, res)
+			cache.Set(cacheKey, res, cacheTTL)
 			response = res
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,13 +148,17 @@ func StartServer(listenInterface string,
 	writeConcurrency int64) {
 
 	r := mux.NewRouter()
+	cacheTTL := viper.GetDuration("query_cache_ttl")
+	if cacheTTL == 0 {
+		cacheTTL = 10 * time.Minute
+	}
 
 	graphUpdater := knowledge.NewGraphUpdater(database, schemaPersistor)
 
 	listSourcesHandler := listSources(sourcesRegistry)
 	getSourceGraphHandler := getSourceGraph(sourcesRegistry, schemaPersistor)
 	getDatabaseDetailsHandler := getDatabaseDetails(database)
-	postQueryHandler := handlers.PostQuery(database, queryHistorizer, viper.GetDuration("query_cache_ttl"))
+	postQueryHandler := handlers.PostQuery(database, queryHistorizer, cacheTTL)
 	flushDatabaseHandler := flushDatabase(database)
 
 	if viper.GetString("password") != "" {


### PR DESCRIPTION
if the env variable GRAPHKB_QUERY_MAX_TIME isn't defined, cacheTTL will equal 0 and the cache never expires for cacheTTL value < 1. This default value will avoid this unwanted behavior