### PR TITLE
schema: add option to validate asset values

### DIFF
--- a/graphkb/helper.go
+++ b/graphkb/helper.go
@@ -1,6 +1,8 @@
 package graphkb
 
 import (
+	"regexp"
+
 	"github.com/clems4ever/go-graphkb/internal/schema"
 )
 
@@ -13,7 +15,37 @@ func CreateRelation(fromType schema.AssetType, relation, toType schema.AssetType
 	}
 }
 
+// CreateAssetOption is an option that can be used when creating an asset
+type CreateAssetOption func(asset AssetType)
+
+// WithRegexpValidation adds a regexp validation check to an asset
+func WithRegexpValidation(r string) CreateAssetOption {
+	reg := regexp.MustCompile(r)
+	return func(asset AssetType) {
+		schema.AddAssetValidator(asset, func(s string) bool {
+			return reg.MatchString(s)
+		})
+	}
+}
+
+// WithValuesValidation adds a check ensuring an asset value is part of the given list
+func WithValuesValidation(expected ...string) CreateAssetOption {
+	ex := make(map[string]bool, len(expected))
+	for _, e := range expected {
+		ex[e] = true
+	}
+	return func(asset AssetType) {
+		schema.AddAssetValidator(asset, func(s string) bool {
+			return ex[s]
+		})
+	}
+}
+
 // CreateAsset helper function for creating an asset
-func CreateAsset(fromType string) AssetType {
-	return schema.AssetType(fromType)
+func CreateAsset(fromType string, options ...CreateAssetOption) AssetType {
+	asset := schema.AssetType(fromType)
+	for _, o := range options {
+		o(asset)
+	}
+	return asset
 }

--- a/graphkb/helper_test.go
+++ b/graphkb/helper_test.go
@@ -1,0 +1,18 @@
+package graphkb
+
+import (
+	"testing"
+
+	"github.com/clems4ever/go-graphkb/internal/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAsset(t *testing.T) {
+	asset := CreateAsset("foo")
+	validators, _ := schema.AssetValidationRegistry.Get(asset)
+	require.Empty(t, validators)
+
+	asset = CreateAsset("foo", WithRegexpValidation(".*"))
+	validators, _ = schema.AssetValidationRegistry.Get(asset)
+	require.Equal(t, 1, len(validators))
+}

--- a/internal/knowledge/graph.go
+++ b/internal/knowledge/graph.go
@@ -2,6 +2,7 @@ package knowledge
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/clems4ever/go-graphkb/internal/schema"
 
@@ -56,10 +57,17 @@ func NewGraph() *Graph {
 }
 
 // AddAsset add an asset to the graph
-func (g *Graph) AddAsset(assetType schema.AssetType, assetKey string) AssetKey {
+func (g *Graph) AddAsset(assetType schema.AssetType, assetKey string) (AssetKey, error) {
+	validators, _ := schema.AssetValidationRegistry.Get(assetType)
+	for _, v := range validators {
+		if !v(assetKey) {
+			return AssetKey{}, fmt.Errorf("asset value %q does not match the type %q validators", assetKey, assetType)
+		}
+	}
+
 	asset := Asset{Type: assetType, Key: assetKey}
 	g.assets.Add(asset)
-	return AssetKey(asset)
+	return AssetKey(asset), nil
 }
 
 // AddRelation add a relation to the graph

--- a/internal/knowledge/graph_binder.go
+++ b/internal/knowledge/graph_binder.go
@@ -1,6 +1,10 @@
 package knowledge
 
-import "github.com/clems4ever/go-graphkb/internal/schema"
+import (
+	"fmt"
+
+	"github.com/clems4ever/go-graphkb/internal/schema"
+)
 
 // GraphBinder represent a graph builder which bind assets and relations to graph schema provided by the source
 type GraphBinder struct {
@@ -15,13 +19,21 @@ func NewGraphBinder(graph *Graph) *GraphBinder {
 }
 
 // Relate relate one asset to another
-func (gb *GraphBinder) Relate(from string, relationType schema.RelationType, to string) {
-	fromAsset := gb.graph.AddAsset(relationType.FromType, from)
-	toAsset := gb.graph.AddAsset(relationType.ToType, to)
+func (gb *GraphBinder) Relate(from string, relationType schema.RelationType, to string) error {
+	fromAsset, err := gb.graph.AddAsset(relationType.FromType, from)
+	if err != nil {
+		return fmt.Errorf("relate: from asset: %w", err)
+	}
+	toAsset, err := gb.graph.AddAsset(relationType.ToType, to)
+	if err != nil {
+		return fmt.Errorf("relate: to asset: %w", err)
+	}
 	gb.graph.AddRelation(fromAsset, relationType.Type, toAsset)
+	return nil
 }
 
 // Bind bind one asset to a type
-func (gb *GraphBinder) Bind(asset string, assetType schema.AssetType) {
-	gb.graph.AddAsset(assetType, asset)
+func (gb *GraphBinder) Bind(asset string, assetType schema.AssetType) error {
+	_, err := gb.graph.AddAsset(assetType, asset)
+	return err
 }

--- a/internal/knowledge/graph_test.go
+++ b/internal/knowledge/graph_test.go
@@ -13,8 +13,10 @@ type GraphSuite struct {
 func (s *GraphSuite) TestShouldTestGraphsAreEqual() {
 	g := NewGraph()
 
-	ip1 := g.AddAsset("ip", "127.0.0.1")
-	ip2 := g.AddAsset("ip", "127.0.0.2")
+	ip1, err := g.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g.AddAsset("ip", "127.0.0.2")
+	s.Require().NoError(err)
 	g.AddRelation(ip1, "linked", ip2)
 
 	s.Assert().True(g.Equal(g))
@@ -23,8 +25,10 @@ func (s *GraphSuite) TestShouldTestGraphsAreEqual() {
 func (s *GraphSuite) TestShouldTestCopiedGraphsAreEqual() {
 	g := NewGraph()
 
-	ip1 := g.AddAsset("ip", "127.0.0.1")
-	ip2 := g.AddAsset("ip", "127.0.0.2")
+	ip1, err := g.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g.AddAsset("ip", "127.0.0.2")
+	s.Require().NoError(err)
 	g.AddRelation(ip1, "linked", ip2)
 
 	g2 := g.Copy()
@@ -36,8 +40,10 @@ func (s *GraphSuite) TestShouldTestCopiedGraphsAreEqual() {
 func (s *GraphSuite) TestShouldTestGraphsAreDifferent() {
 	g := NewGraph()
 
-	ip1 := g.AddAsset("ip", "127.0.0.1")
-	ip2 := g.AddAsset("ip", "127.0.0.2")
+	ip1, err := g.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g.AddAsset("ip", "127.0.0.2")
+	s.Require().NoError(err)
 	g.AddRelation(ip1, "linked", ip2)
 
 	g2 := g.Copy()
@@ -50,8 +56,10 @@ func (s *GraphSuite) TestShouldTestGraphsAreDifferent() {
 func (s *GraphSuite) TestShouldTestGraphsHasAsset() {
 	g := NewGraph()
 
-	ip1 := g.AddAsset("ip", "127.0.0.1")
-	ip2 := g.AddAsset("ip", "127.0.0.2")
+	ip1, err := g.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g.AddAsset("ip", "127.0.0.2")
+	s.Require().NoError(err)
 	g.AddRelation(ip1, "linked", ip2)
 
 	s.Assert().True(g.HasAsset(Asset(ip1)))
@@ -61,8 +69,10 @@ func (s *GraphSuite) TestShouldTestGraphsHasAsset() {
 func (s *GraphSuite) TestShouldTestGraphsHasRelation() {
 	g := NewGraph()
 
-	ip1 := g.AddAsset("ip", "127.0.0.1")
-	ip2 := g.AddAsset("ip", "127.0.0.2")
+	ip1, err := g.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g.AddAsset("ip", "127.0.0.2")
+	s.Require().NoError(err)
 	rel := g.AddRelation(ip1, "linked", ip2)
 
 	s.Assert().True(g.HasRelation(Relation(rel)))

--- a/internal/knowledge/graph_updates_test.go
+++ b/internal/knowledge/graph_updates_test.go
@@ -3,6 +3,8 @@ package knowledge
 import (
 	"testing"
 
+	"github.com/clems4ever/go-graphkb/internal/schema"
+	"github.com/clems4ever/go-graphkb/internal/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -12,8 +14,10 @@ type SourceUpdatesSuite struct {
 
 func (s *SourceUpdatesSuite) TestShouldUpsertForCreatingGraph() {
 	g := NewGraph()
-	ip1 := g.AddAsset("ip", "127.0.0.1")
-	ip2 := g.AddAsset("ip", "192.168.0.1")
+	ip1, err := g.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g.AddAsset("ip", "192.168.0.1")
+	s.Require().NoError(err)
 
 	rel := g.AddRelation(ip1, "linked", ip2)
 
@@ -30,14 +34,18 @@ func (s *SourceUpdatesSuite) TestShouldUpsertForCreatingGraph() {
 
 func (s *SourceUpdatesSuite) TestShouldUpsertAssets() {
 	g1 := NewGraph()
-	ip1 := g1.AddAsset("ip", "127.0.0.1")
-	ip2 := g1.AddAsset("ip", "192.168.0.1")
+	ip1, err := g1.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g1.AddAsset("ip", "192.168.0.1")
+	s.Require().NoError(err)
 
 	g1.AddRelation(ip1, "linked", ip2)
 	g2 := g1.Copy()
 
-	ip3 := g2.AddAsset("ip", "10.0.0.1")
-	ip4 := g2.AddAsset("ip", "10.0.0.2")
+	ip3, err := g2.AddAsset("ip", "10.0.0.1")
+	s.Require().NoError(err)
+	ip4, err := g2.AddAsset("ip", "10.0.0.2")
+	s.Require().NoError(err)
 
 	bulk := GenerateGraphUpdatesBulk(g1, g2)
 
@@ -51,13 +59,16 @@ func (s *SourceUpdatesSuite) TestShouldUpsertAssets() {
 
 func (s *SourceUpdatesSuite) TestShouldUpsertRelations() {
 	g1 := NewGraph()
-	ip1 := g1.AddAsset("ip", "127.0.0.1")
-	ip2 := g1.AddAsset("ip", "192.168.0.1")
+	ip1, err := g1.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g1.AddAsset("ip", "192.168.0.1")
+	s.Require().NoError(err)
 
 	g1.AddRelation(ip1, "linked", ip2)
 	g2 := g1.Copy()
 
-	ip3 := g2.AddAsset("ip", "10.0.0.1")
+	ip3, err := g2.AddAsset("ip", "10.0.0.1")
+	s.Require().NoError(err)
 	r1 := g2.AddRelation(ip3, "linked", ip1)
 	r2 := g2.AddRelation(ip3, "linked", ip2)
 
@@ -74,8 +85,10 @@ func (s *SourceUpdatesSuite) TestShouldUpsertRelations() {
 
 func (s *SourceUpdatesSuite) TestShouldRemoveGraph() {
 	g1 := NewGraph()
-	ip1 := g1.AddAsset("ip", "127.0.0.1")
-	ip2 := g1.AddAsset("ip", "192.168.0.1")
+	ip1, err := g1.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g1.AddAsset("ip", "192.168.0.1")
+	s.Require().NoError(err)
 	r := g1.AddRelation(ip1, "linked", ip2)
 
 	bulk := GenerateGraphUpdatesBulk(g1, nil)
@@ -91,12 +104,15 @@ func (s *SourceUpdatesSuite) TestShouldRemoveGraph() {
 
 func (s *SourceUpdatesSuite) TestShouldGenerateBulkOfSubgraph() {
 	g1 := NewGraph()
-	ip1 := g1.AddAsset("ip", "127.0.0.1")
-	ip2 := g1.AddAsset("ip", "192.168.0.1")
+	ip1, err := g1.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g1.AddAsset("ip", "192.168.0.1")
+	s.Require().NoError(err)
 	r := g1.AddRelation(ip1, "linked", ip2)
 
 	g2 := NewGraph()
-	g2.AddAsset("ip", "127.0.0.1")
+	_, err = g2.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
 
 	bulk := GenerateGraphUpdatesBulk(g1, g2)
 
@@ -111,13 +127,17 @@ func (s *SourceUpdatesSuite) TestShouldGenerateBulkOfSubgraph() {
 
 func (s *SourceUpdatesSuite) TestShouldGenerateBulkForMixedAdditionsAndRemovals() {
 	g1 := NewGraph()
-	ip1 := g1.AddAsset("ip", "127.0.0.1")
-	ip2 := g1.AddAsset("ip", "192.168.0.1")
+	ip1, err := g1.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip2, err := g1.AddAsset("ip", "192.168.0.1")
+	s.Require().NoError(err)
 	r := g1.AddRelation(ip1, "linked", ip2)
 
 	g2 := NewGraph()
-	g2.AddAsset("ip", "127.0.0.1")
-	ip3 := g2.AddAsset("ip", "10.0.0.1")
+	_, err = g2.AddAsset("ip", "127.0.0.1")
+	s.Require().NoError(err)
+	ip3, err := g2.AddAsset("ip", "10.0.0.1")
+	s.Require().NoError(err)
 	r2 := g2.AddRelation(ip3, "linked", ip2)
 
 	bulk := GenerateGraphUpdatesBulk(g1, g2)
@@ -131,6 +151,26 @@ func (s *SourceUpdatesSuite) TestShouldGenerateBulkForMixedAdditionsAndRemovals(
 	s.Assert().ElementsMatch(bulk.GetRelationUpserts(), []Relation{r2})
 	s.Assert().ElementsMatch(bulk.GetAssetRemovals(), []Asset{Asset(ip2)})
 	s.Assert().ElementsMatch(bulk.GetRelationRemovals(), []Relation{r})
+}
+
+func (s *SourceUpdatesSuite) TestAssetValidation() {
+	asset := schema.AssetType("asset")
+	reg := schema.AssetValidationRegistry.(*utils.Registry[schema.AssetType, []schema.AssetValidationFunc])
+
+	defer reg.Del(asset)
+	schema.AddAssetValidator(asset, func(s string) bool {
+		return s == "foo"
+	})
+
+	g := NewGraph()
+
+	_, err := g.AddAsset(asset, "bar")
+	s.Require().Error(err)
+	s.Require().Empty(g.Assets())
+
+	_, err = g.AddAsset(asset, "foo")
+	s.Require().NoError(err)
+	s.Require().Equal([]Asset{{Type: asset, Key: "foo"}}, g.Assets())
 }
 
 func TestGraphUpdatesSuite(t *testing.T) {

--- a/internal/schema/validation.go
+++ b/internal/schema/validation.go
@@ -1,0 +1,21 @@
+package schema
+
+import (
+	"github.com/clems4ever/go-graphkb/internal/utils"
+)
+
+type AssetValidationFunc func(string) bool
+
+type ValidationRegistry interface {
+	Get(AssetType) ([]AssetValidationFunc, bool)
+}
+
+var (
+	AssetValidationRegistry ValidationRegistry = utils.NewRegistry[AssetType, []AssetValidationFunc]()
+)
+
+func AddAssetValidator(asset AssetType, v AssetValidationFunc) {
+	validators, _ := AssetValidationRegistry.Get(asset)
+	validators = append(validators, v)
+	AssetValidationRegistry.(*utils.Registry[AssetType, []AssetValidationFunc]).Set(asset, validators)
+}

--- a/internal/utils/registry.go
+++ b/internal/utils/registry.go
@@ -1,0 +1,22 @@
+package utils
+
+type Registry[T comparable, U any] struct {
+	values map[T]U
+}
+
+func NewRegistry[T comparable, U any]() *Registry[T, U] {
+	return &Registry[T, U]{values: make(map[T]U)}
+}
+
+func (r *Registry[T, U]) Get(k T) (U, bool) {
+	v, ok := r.values[k]
+	return v, ok
+}
+
+func (r *Registry[T, U]) Set(k T, v U) {
+	r.values[k] = v
+}
+
+func (r *Registry[T, U]) Del(k T) {
+	delete(r.values, k)
+}


### PR DESCRIPTION
This option allows to specify a regexp when creating an asset that is evaluated on the client (source) side and fails the transaction if the value does not match.
