### PR TITLE
mariadb: change assets.value collation to utf8mb4_nopad_bin

### DIFF
--- a/internal/database/mariadb.go
+++ b/internal/database/mariadb.go
@@ -63,7 +63,7 @@ func (m *MariaDB) InitializeSchema() error {
 	_, err = m.db.ExecContext(context.Background(), `
 		CREATE TABLE IF NOT EXISTS assets (
 			id BIGINT UNSIGNED NOT NULL,
-			value VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+			value VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_nopad_bin NOT NULL,
 			type VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
 
 			CONSTRAINT pk_asset PRIMARY KEY (id),


### PR DESCRIPTION
The previous value: utf8mb4_bin was ignoring trailing whitespaces when
comparing values. This created a discrepency from the fnv id hash we
were using and failed in this case :

Step 1:
* insert asset id=1 key=foo value="bar": OK
* insert assets_by_sources asset_id=1 source_id=42: OK

Step 2:
* insert asset id=2 key=foo value="bar ": with utf8mb4_bin, the unique index
  on (type,value) prevents insertion, we continue
* insert assets_by_sources: asset_id=2 source_id=42: FK FAILs because
  asset_id=2 does not exist