### PR TITLE
rework graph size monitor

### DIFF
--- a/internal/knowledge/graphdb.go
+++ b/internal/knowledge/graphdb.go
@@ -33,9 +33,9 @@ type GraphDB interface {
 	FlushAll(ctx context.Context) error
 
 	CountAssets(ctx context.Context) (int64, error)
-	CountAssetsBySource(ctx context.Context, sourceName string) (int64, error)
+	CountAssetsBySource(ctx context.Context) (map[string]int64, error)
 	CountRelations(ctx context.Context) (int64, error)
-	CountRelationsBySource(ctx context.Context, sourceName string) (int64, error)
+	CountRelationsBySource(ctx context.Context) (map[string]int64, error)
 
 	Query(ctx context.Context, query SQLTranslation) (*GraphQueryResult, error)
 

--- a/internal/server/monitoring.go
+++ b/internal/server/monitoring.go
@@ -6,11 +6,94 @@ import (
 
 	"github.com/clems4ever/go-graphkb/internal/knowledge"
 	"github.com/clems4ever/go-graphkb/internal/metrics"
-	"github.com/clems4ever/go-graphkb/internal/sources"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+type dbMonitor struct {
+	database knowledge.GraphDB
+
+	AssetCount    int64
+	RelationCount int64
+
+	AssetsBySource    map[string]int64
+	RelationsBySource map[string]int64
+}
+
+func newDBMonitor(database knowledge.GraphDB) *dbMonitor {
+	return &dbMonitor{
+		database:          database,
+		AssetsBySource:    map[string]int64{},
+		RelationsBySource: map[string]int64{},
+	}
+}
+
+func (m *dbMonitor) Start() {
+	interval := getMonitoringIntervalSeconds()
+
+	logrus.Infof("monitoring of the database every %s", interval)
+	go func() {
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), interval)
+			err := m.refresh(ctx)
+			if err != nil {
+				logrus.Errorf("db monitor: %s", err)
+			}
+			cancel()
+		}
+	}()
+}
+
+func (m *dbMonitor) refresh(ctx context.Context) error {
+	c, err := m.database.CountAssets(ctx)
+	if err != nil {
+		metrics.GraphAssetsAggregatedGauge.Set(-1)
+	} else {
+		m.AssetCount = c
+		metrics.GraphAssetsAggregatedGauge.Set(float64(c))
+	}
+
+	c, err = m.database.CountRelations(ctx)
+	if err != nil {
+		metrics.GraphRelationsAggregatedGauge.Set(-1)
+	} else {
+		m.RelationCount = c
+		metrics.GraphRelationsAggregatedGauge.Set(float64(c))
+	}
+
+	ac, err := m.database.CountAssetsBySource(ctx)
+	if err != nil {
+		metrics.GraphAssetsTotalGauge.Reset()
+	} else {
+		m.AssetsBySource = ac
+		for name, count := range ac {
+			metrics.GraphAssetsTotalGauge.With(prometheus.Labels{"source": name}).Set(float64(count))
+		}
+	}
+
+	ac, err = m.database.CountRelationsBySource(ctx)
+	if err != nil {
+		metrics.GraphRelationsTotalGauge.Reset()
+	} else {
+		m.RelationsBySource = ac
+		for name, count := range ac {
+			metrics.GraphRelationsTotalGauge.With(prometheus.Labels{"source": name}).Set(float64(count))
+		}
+	}
+
+	dbMetrics, err := m.database.CollectMetrics(ctx)
+	if err != nil {
+		logrus.Errorf("Unable to collect metrics from the database: %v", err)
+		metrics.DatabaseMetricsGauge.Reset()
+	} else {
+		for k, v := range dbMetrics {
+			metrics.DatabaseMetricsGauge.With(prometheus.Labels{"name": k}).Set(float64(v))
+		}
+	}
+
+	return nil
+}
 
 func getMonitoringIntervalSeconds() time.Duration {
 	intervalDuration := viper.GetDuration("monitoring_interval_duration")
@@ -18,70 +101,4 @@ func getMonitoringIntervalSeconds() time.Duration {
 		intervalDuration = 60 * time.Second
 	}
 	return intervalDuration
-}
-
-// startGraphSizeMonitoring start a background process regularly checking the size of the graph to expose it as a prometheus metric
-func startGraphSizeMonitoring(interval time.Duration, database knowledge.GraphDB, sourcesRegistry sources.Registry) {
-	monitorForOneIteration := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), interval)
-		defer cancel()
-
-		logrus.Debug("Start monitoring the graph size...")
-		assetsCount, err := database.CountAssets(ctx)
-		if err != nil {
-			metrics.GraphAssetsAggregatedGauge.Set(-1)
-		} else {
-			metrics.GraphAssetsAggregatedGauge.Set(float64(assetsCount))
-		}
-
-		relationsCount, err := database.CountRelations(ctx)
-		if err != nil {
-			metrics.GraphRelationsAggregatedGauge.Set(-1)
-		} else {
-			metrics.GraphRelationsAggregatedGauge.Set(float64(relationsCount))
-		}
-
-		sources, err := sourcesRegistry.ListSources(ctx)
-		if err != nil {
-			logrus.Errorf("Unable to list sources for monitoring: %v", err)
-			metrics.GraphAssetsTotalGauge.Reset()
-			metrics.GraphRelationsTotalGauge.Reset()
-		}
-
-		for s := range sources {
-			assetsCount, err := database.CountAssetsBySource(ctx, s)
-			if err != nil {
-				logrus.Errorf("Unable to count assets of source %s for monitoring: %s", s, err)
-				metrics.GraphAssetsTotalGauge.Reset()
-			} else {
-				metrics.GraphAssetsTotalGauge.With(prometheus.Labels{"source": s}).Set(float64(assetsCount))
-			}
-
-			relationsCount, err := database.CountRelationsBySource(ctx, s)
-			if err != nil {
-				logrus.Errorf("Unable to count relations of source %s for monitoring: %s", s, err)
-				metrics.GraphRelationsTotalGauge.Reset()
-			} else {
-				metrics.GraphRelationsTotalGauge.With(prometheus.Labels{"source": s}).Set(float64(relationsCount))
-			}
-		}
-
-		m, err := database.CollectMetrics(ctx)
-		if err != nil {
-			logrus.Errorf("Unable to collect metrics from the database: %v", err)
-			metrics.DatabaseMetricsGauge.Reset()
-		} else {
-			for k, v := range m {
-				metrics.DatabaseMetricsGauge.With(prometheus.Labels{"name": k}).Set(float64(v))
-			}
-		}
-	}
-
-	logrus.Infof("Monitoring of the graph size will happen every %ds", int(interval/time.Second))
-	go func() {
-		for {
-			monitorForOneIteration()
-			time.Sleep(interval)
-		}
-	}()
 }


### PR DESCRIPTION
* Gather data about assets/relations count by source in one query to be
  more efficient
* Store the results for use in /api/database to speed up the endpoint
  and avoid costly queries to be run each time it is called