### PR TITLE
feat: add user metrics for kb consumers

### DIFF
--- a/internal/database/mariadb.go
+++ b/internal/database/mariadb.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/VividCortex/mysqlerr"
+	"github.com/clems4ever/go-graphkb/internal/kbcontext"
 	"github.com/clems4ever/go-graphkb/internal/knowledge"
 	"github.com/clems4ever/go-graphkb/internal/schema"
 	"github.com/clems4ever/go-graphkb/internal/utils"
@@ -641,12 +642,19 @@ func (m *MariaDB) Close() error {
 // Query the database with provided intermediate query representation
 func (m *MariaDB) Query(ctx context.Context, sqlTranslation knowledge.SQLTranslation) (*knowledge.GraphQueryResult, error) {
 	deadline, ok := ctx.Deadline()
+
 	// If there is a deadline, we make sure the query stops right after it has been reached.
 	if ok {
 		// Query can take 35 seconds max before being aborted...
 		sqlTranslation.Query = fmt.Sprintf("SET STATEMENT max_statement_time=%f FOR %s", time.Until(deadline).Seconds()+5, sqlTranslation.Query)
 	}
-	logrus.Debug("Query to be executed: ", sqlTranslation.Query)
+
+	user, ok := kbcontext.XForwardedUser(ctx)
+	if !ok {
+		user = ""
+	}
+
+	logrus.Debugf("Query to be executed for user %s: %s", user, sqlTranslation.Query)
 
 	cursor, err := NewMariaDBCursor(ctx, m.db, sqlTranslation)
 	if err != nil {

--- a/internal/kbcontext/context.go
+++ b/internal/kbcontext/context.go
@@ -1,0 +1,21 @@
+package kbcontext
+
+import (
+	"context"
+)
+
+var (
+	ContextKeyXForwardedUser = contextKey("xForwardedUser")
+)
+
+type contextKey string
+
+func (c contextKey) String() string {
+	return "server" + string(c)
+}
+
+// XForwardedUser gets the service user from context
+func XForwardedUser(ctx context.Context) (string, bool) {
+	xForwardedUser, ok := ctx.Value(ContextKeyXForwardedUser).(string)
+	return xForwardedUser, ok
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,7 +27,7 @@ var GraphQueryTimeExecution = promauto.NewHistogramVec(prometheus.HistogramOpts{
 var GraphQueryStatusCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "go_graphkb_query_status_counter",
 	Help: "The number of queries executed by status: (ERROR|SUCCESS)",
-}, []string{"status"})
+}, []string{"status", "user"})
 
 // ********************* GRAPH METRICS ******************
 


### PR DESCRIPTION
* The Query Status Counter now has a new Prometheus Label for users.
* Added a new kbcontext package that implements the context pattern to avoid hardcoding keys and values and enables the implementation of new header based metrics in a scalable way.