### PR TITLE
fix(client): tx commit: perform inserts before deletes

### DIFF
--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -104,32 +104,6 @@ func (cgt *Transaction) Commit() error {
 	count, err := chunkedTransfer(
 		cgt.parallelization,
 		cgt.chunkSize,
-		cgt.graph.Relations(),
-		knowledge.GraphEntryRemove,
-		cgt.client.DeleteRelations,
-	)
-	if err != nil {
-		return err
-	}
-	logrus.Debugf("Deleted %d old relations", count)
-	totalCount += count
-
-	count, err = chunkedTransfer(
-		cgt.parallelization,
-		cgt.chunkSize,
-		cgt.graph.Assets(),
-		knowledge.GraphEntryRemove,
-		cgt.client.DeleteAssets,
-	)
-	if err != nil {
-		return err
-	}
-	logrus.Debugf("Deleted %d old assets", count)
-	totalCount += count
-
-	count, err = chunkedTransfer(
-		cgt.parallelization,
-		cgt.chunkSize,
 		cgt.graph.Assets(),
 		knowledge.GraphEntryAdd,
 		cgt.client.InsertAssets,
@@ -151,6 +125,32 @@ func (cgt *Transaction) Commit() error {
 		return err
 	}
 	logrus.Debugf("Inserted %d new relations", count)
+	totalCount += count
+
+	count, err = chunkedTransfer(
+		cgt.parallelization,
+		cgt.chunkSize,
+		cgt.graph.Relations(),
+		knowledge.GraphEntryRemove,
+		cgt.client.DeleteRelations,
+	)
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("Deleted %d old relations", count)
+	totalCount += count
+
+	count, err = chunkedTransfer(
+		cgt.parallelization,
+		cgt.chunkSize,
+		cgt.graph.Assets(),
+		knowledge.GraphEntryRemove,
+		cgt.client.DeleteAssets,
+	)
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("Deleted %d old assets", count)
 	totalCount += count
 
 	if totalCount == 0 {


### PR DESCRIPTION
We used to delete old assets and relations before inserting new ones which caused data to be unavailable for a brief moment or for longer in case of failure.