### PR TITLE
fix(monitor): add missing sleep statement during refresh

### DIFF
--- a/internal/server/monitoring.go
+++ b/internal/server/monitoring.go
@@ -41,6 +41,8 @@ func (m *dbMonitor) Start() {
 				logrus.Errorf("db monitor: %s", err)
 			}
 			cancel()
+
+			time.Sleep(interval)
 		}
 	}()
 }


### PR DESCRIPTION
A sleep statement was missing in the monitor loop, causing the select count queries to run constantly.