### PR TITLE
fix(tx): do not consider assets from relations as present in the graph

### DIFF
--- a/internal/knowledge/graph_encoder_decoder.go
+++ b/internal/knowledge/graph_encoder_decoder.go
@@ -86,8 +86,7 @@ func (ge *GraphDecoder) Decode(graph *Graph) error {
 			if err != nil {
 				return err
 			}
-			graph.AddAsset(relation.From.Type, relation.From.Key)
-			graph.AddAsset(relation.To.Type, relation.To.Key)
+
 			graph.AddRelation(relation.From, relation.Type, relation.To)
 		}
 	}


### PR DESCRIPTION
When creating a transaction we load the existing assets and relations to perform a diff and push the updates. We mistakenly considered that assets coming from relation were part of the graph for the source. However this is not necessarily true when there are errors in the graph. We now only consider assets explicitely listed in order to repair the graph if some data is missing.